### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nephelaiio/ansible-role-packetbeat/security/code-scanning/4](https://github.com/nephelaiio/ansible-role-packetbeat/security/code-scanning/4)

To fix the problem, you should add a `permissions` key to the workflow, either at the root level (which applies to all jobs unless overwritten) or directly within the `lint` job definition. Since this workflow only checks out code, installs dependencies, and runs test/lint commands, it does not require any write permissions. Therefore, the minimal privilege required is `contents: read`. 

The best way to fix this is to add:
```yaml
permissions:
  contents: read
```
directly below the `name` field at the root of the workflow (i.e., after line 2 and before `on:` in the given snippet for global effect). This will restrict the GITHUB_TOKEN in all jobs to read-only access on repository contents, following CodeQL's recommendations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
